### PR TITLE
Fix: Make Conway's Game of Life axes visible

### DIFF
--- a/Python/life_game.py
+++ b/Python/life_game.py
@@ -39,7 +39,6 @@ def main():
     fig, ax = plt.subplots()
     img = ax.imshow(grid, interpolation='nearest', cmap='binary')
     ax.set_title('Conway\'s Game of Life')
-    ax.axis('off')
 
     ani = animation.FuncAnimation(fig, update, fargs=(img, grid),
                                   frames=200, interval=100, save_count=50)

--- a/Python/test_life_game.py
+++ b/Python/test_life_game.py
@@ -1,0 +1,16 @@
+import unittest
+from unittest.mock import patch
+import matplotlib.pyplot as plt
+from life_game import main
+
+class TestLifeGame(unittest.TestCase):
+    @patch('matplotlib.pyplot.show')
+    def test_axes_are_visible(self, mock_show):
+        main()
+        fig = plt.gcf()
+        ax = fig.gca()
+        self.assertEqual(ax.get_title(), "Conway's Game of Life")
+        self.assertTrue(ax.axison)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit addresses an issue where the axes of the plot in Conway's Game of Life were hidden. While this may have been an intentional design choice for a cleaner visualization, it is being treated as a bug for the purpose of this task. The fix involves removing the line of code that hides the axes.

A new test case has been added to verify that the axes are visible after the change. The test is located in `Python/test_life_game.py`.